### PR TITLE
Update nixpkgs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use nix
+watch_file ./nixpkgs.nix

--- a/default.nix
+++ b/default.nix
@@ -1,23 +1,5 @@
 with import ./nixpkgs.nix {
   config = {};
-  overlays = [
-    (selfPkgs: pkgs: rec {
-      python3 = pkgs.python3.override rec {
-        packageOverrides = self: super: rec {
-          # PyOpenGL is broken on nixpkgs
-          # https://github.com/NixOS/nixpkgs/issues/76822
-          pyopengl = super.pyopengl.overridePythonAttrs(old:  rec {
-            version = "3.1.0";
-            src = self.fetchPypi {
-              pname = "PyOpenGL";
-              inherit version;
-              sha256 = "1byxjj6a8rwzhxhjqlc588zdad2qwxdd7vlam2653ylll31waiwv";
-            };
-          });
-        };
-      };
-    })
-  ];
 };
 mkShell {
   buildInputs = [

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -13,9 +13,9 @@ and the control sum computed using `sha256`.
 */
 
 let
-  # nixpkgs-unstable 2020-01-30
-  sha256 = "0p7amn7raw5rahyxw3jq21378n7i7ld4122hm5dddlbcvmpw60p0";
-  rev = "690dd986b2349d2c9cd6437e820954ed400f37f7";
+  # nixpkgs-master 2020-02-25
+  sha256 = "17nv5gwlq6b33c5sxiy1ydhk8f73gx5kvvxfxn55342da1zsj2ys";
+  rev = "8246c35875d1564b99e2e65db229abaa11a09386";
 in
 import (fetchTarball {
   inherit sha256;


### PR DESCRIPTION
It just removes the need for the `PyOpenGL` override.